### PR TITLE
ci: remove upload sarif action from markdownlint workflow

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -19,9 +19,6 @@ on:
 
 permissions:
   contents: read
-  # required for upload-sarif action
-  # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository
-  security-events: write
 
 jobs:
   markdownlint:
@@ -53,7 +50,7 @@ jobs:
         run: cat .github/markdownlint/.markdownlint-cli2.yaml
       - name: Run markdownlint with rules as container
         uses: YannickTeKulve/docker-run-action@0.0.6
-        continue-on-error: true
+        continue-on-error: false
         with:
           image: davidanson/markdownlint-cli2-rules:v0.17.2
           # node user does not have permissions to workspace due to user id mismatch
@@ -62,15 +59,15 @@ jobs:
           run: markdownlint-cli2 --config .github/markdownlint/.markdownlint-cli2.yaml "**/*.md"
       # Needs to be a public repo in order for uploading SARIF files to work
       # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github
-      - uses: github/codeql-action/upload-sarif@v3
-        if: ${{ inputs.code-scanning }}
-        with:
-          # Path to SARIF file relative to the root of the repository
-          sarif_file: markdownlint-cli2-sarif.sarif
-          # Optional category for the results
-          # Used to differentiate multiple results for one commit
-          category: markdownlint
+      # - uses: github/codeql-action/upload-sarif@v3
+      #   if: ${{ inputs.code-scanning }}
+      #   with:
+      #     # Path to SARIF file relative to the root of the repository
+      #     sarif_file: markdownlint-cli2-sarif.sarif
+      #     # Optional category for the results
+      #     # Used to differentiate multiple results for one commit
+      #     category: markdownlint
       # fail if there are markdownlint violations
-      - name: Check markdownlint results
-        run: |
-          grep -q '"results": \[\]' markdownlint-cli2-sarif.sarif
+      # - name: Check markdownlint results
+      #   run: |
+      #     grep -q '"results": \[\]' markdownlint-cli2-sarif.sarif


### PR DESCRIPTION
Don't require `security events: write` permission for linting.