### PR TITLE
fix: improve handling of tags for version tags

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -61,7 +61,7 @@ jobs:
         run: |
           TAG_NAMES=$(echo "$TAGS" | sed 's/\/\./\//g')
           echo "Sanitized tag: $TAG_NAMES"
-          echo "tags='$TAG_NAMES'" >> "$GITHUB_OUTPUT"
+          echo "tags=$TAG_NAMES" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.15.0

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -54,13 +54,14 @@ jobs:
       # special case for .github to strip the leading period away since it is an invalid tag name
       # note that this only works if the tags contains a single tag, not several of them
       - name: Sanitize tag name
-        if: ${{ endsWith(github.repository, '.github') }}
+        id: tags
+        # if: ${{ endsWith(github.repository, '.github') }}
         env:
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          TAG_NAME=$(echo "$TAGS" | sed 's/\/\./\//g')
-          echo "Sanitized tag: $TAG_NAME"
-          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          TAG_NAMES=$(echo "$TAGS" | sed 's/\/\./\//g')
+          echo "Sanitized tag: $TAG_NAMES"
+          echo "tags='$TAG_NAMES'" >> "$GITHUB_OUTPUT"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.15.0
@@ -70,7 +71,7 @@ jobs:
           load: true
           # only push to the registry when it is not a PR (i.e., main branch)
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ env.TAG_NAME || steps.meta.outputs.tags }}
+          tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
           # cache-from: type=gha
@@ -78,11 +79,12 @@ jobs:
       - name: Test image
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
+          TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           # shellcheck disable=SC2086
-          echo docker run --rm "$TAG_NAME" $TEST_COMMAND
+          echo docker run --rm "$TAGS" $TEST_COMMAND
           # shellcheck disable=SC2086
-          docker run --rm "$TAG_NAME" $TEST_COMMAND
+          docker run --rm "$TAGS" $TEST_COMMAND
       # - name: Generate artifact attestation
       #   uses: actions/attest-build-provenance@v2.2.3
       #   with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -62,7 +62,7 @@ jobs:
           TAG_NAMES=$(echo "$TAGS" | sed 's/\/\./\//g')
           echo "Sanitized tag: $TAG_NAMES"
           {
-            echo "TAGS<<"
+            echo "TAGS<<EOF"
             echo "$TAG_NAMES"
             echo EOF
           } >> "$GITHUB_ENV"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -85,6 +85,8 @@ jobs:
           TEST_COMMAND: ${{ inputs.test-command }}
         run: |
           FIRST_TAG=$(echo "$TAGS" | cut -d ' ' -f 1)
+          echo "First tag is $FIRST_TAG"
+          python3 -c "import os; tags = os.environ['TAGS']; print(tags); print(tags.split(' ')); print(tags.split('\n'));"
           # shellcheck disable=SC2086
           echo docker run --rm "$FIRST_TAG" $TEST_COMMAND
           # shellcheck disable=SC2086

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -84,7 +84,7 @@ jobs:
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
         run: |
-          FIRST_TAG=$(echo "$TAGS" | cut -d ' ' -f 1)
+          FIRST_TAG=$(echo "$TAGS" | cut -d '\n' -f 1)
           echo "First tag is $FIRST_TAG"
           python3 -c "import os; tags = os.environ['TAGS']; print(tags); print(tags.split(' ')); print(tags.split('\n'));"
           # shellcheck disable=SC2086

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -84,10 +84,11 @@ jobs:
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
         run: |
+          FIRST_TAG=$(echo "$TAGS" | cut -d ' ' -f 1)
           # shellcheck disable=SC2086
-          echo docker run --rm "$TAGS" $TEST_COMMAND
+          echo docker run --rm "$FIRST_TAG" $TEST_COMMAND
           # shellcheck disable=SC2086
-          docker run --rm "$TAGS" $TEST_COMMAND
+          docker run --rm "$FIRST_TAG" $TEST_COMMAND
       # - name: Generate artifact attestation
       #   uses: actions/attest-build-provenance@v2.2.3
       #   with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -84,7 +84,7 @@ jobs:
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
         run: |
-          FIRST_TAG=$(echo "$TAGS" | cut -d '\n' -f 1)
+          FIRST_TAG=$(echo "$TAGS" | head --lines 1)
           echo "First tag is $FIRST_TAG"
           python3 -c "import os; tags = os.environ['TAGS']; print(tags); print(tags.split(' ')); print(tags.split('\n'));"
           # shellcheck disable=SC2086

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -61,7 +61,11 @@ jobs:
         run: |
           TAG_NAMES=$(echo "$TAGS" | sed 's/\/\./\//g')
           echo "Sanitized tag: $TAG_NAMES"
-          echo "tags=$TAG_NAMES" >> "$GITHUB_OUTPUT"
+          {
+            echo "TAGS<<"
+            echo "$TAG_NAMES"
+            echo EOF
+          } >> "$GITHUB_ENV"
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@v6.15.0
@@ -71,7 +75,7 @@ jobs:
           load: true
           # only push to the registry when it is not a PR (i.e., main branch)
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.tags.outputs.tags }}
+          tags: ${{ env.TAGS }}
           labels: ${{ steps.meta.outputs.labels }}
           # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
           # cache-from: type=gha
@@ -79,7 +83,6 @@ jobs:
       - name: Test image
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
-          TAGS: ${{ steps.tags.outputs.tags }}
         run: |
           # shellcheck disable=SC2086
           echo docker run --rm "$TAGS" $TEST_COMMAND


### PR DESCRIPTION
When running the build for git tags, there are two image tags being reported by the docker metadata action.
One for the version, and `latest`.

Handle the tags properly and only use one of them when testing the image.